### PR TITLE
Expose backing tinyMCE instance

### DIFF
--- a/dist/TinyMCEInput.js
+++ b/dist/TinyMCEInput.js
@@ -165,6 +165,7 @@ var TinyMCEInput = React.createClass({
       setup: this.setupEditor
     });
     tinymce.init(tinymceConfig);
+    this.editor = tinymce.get(this.state.id);
   },
   initTinyMCE: function initTinyMCE() {
     var currentTime = Date.now();

--- a/src/TinyMCEInput.js
+++ b/src/TinyMCEInput.js
@@ -172,6 +172,7 @@ var TinyMCEInput = React.createClass({
       }
     );
     tinymce.init(tinymceConfig);
+    this.editor = tinymce.get(this.state.id);
   },
   initTinyMCE: function() {
     var currentTime = Date.now();


### PR DESCRIPTION
It is sometimes advantageous to get the tinyMCE editor instance.

Ideally everything can be passed as props, but this is a good workaround until the API is fully covered.
